### PR TITLE
Compatibility with MediaWiki 1.35+

### DIFF
--- a/CustomSubtitle.i18n.php
+++ b/CustomSubtitle.i18n.php
@@ -8,10 +8,10 @@ $magicWords = [];
 
 /* English */
 $magicWords['en'] = [
-   'subtitle' => [ 0, 'subtitle' ],
+	'subtitle' => [ 0, 'subtitle' ],
 ];
 
 /* French */
 $magicWords['fr'] = [
-   'subtitle' => [ 0, 'soustitre', 'subtitle' ],
+	'subtitle' => [ 0, 'soustitre', 'subtitle' ],
 ];

--- a/extension.json
+++ b/extension.json
@@ -1,16 +1,16 @@
 {
-    "name": "CustomSubtitle",
-    "author": "Antoine Lamielle",
-    "url": "https://github.com/lingua-libre/CustomSubtitle",
-    "license-name": "GPL-2.0+",
-    "version": "0.1.0",
-    "namemsg": "customSubtitle",
-    "descriptionmsg": "customSubtitle-desc",
+	"name": "CustomSubtitle",
+	"author": "Antoine Lamielle",
+	"url": "https://github.com/lingua-libre/CustomSubtitle",
+	"license-name": "GPL-2.0+",
+	"version": "0.1.0",
+	"namemsg": "customSubtitle",
+	"descriptionmsg": "customSubtitle-desc",
 	"type": "parserhook",
-    "manifest_version": 1,
-    "MessagesDirs": {
-        "CustomSubtitle": [ "i18n" ]
-    },
+	"manifest_version": 1,
+	"MessagesDirs": {
+		"CustomSubtitle": [ "i18n" ]
+	},
 	"AutoloadClasses": {
 		"CustomSubtitleHooks": "src/CustomSubtitleHooks.php"
 	},

--- a/src/CustomSubtitleHooks.php
+++ b/src/CustomSubtitleHooks.php
@@ -12,7 +12,7 @@ class CustomSubtitleHooks {
 		global $wgOut;
 
 		// Put the subtitle in the tagline
-		$parser->disableCache();
+		$parser->getOutput()->updateCacheExpiry( 0 );
 		$wgOut->addSubtitle( $parser->recursiveTagParse( $subtitleText ) );
 
 		// Replace this magic word by a blank in the resulting wikitext

--- a/src/CustomSubtitleHooks.php
+++ b/src/CustomSubtitleHooks.php
@@ -1,21 +1,21 @@
 <?php
 class CustomSubtitleHooks {
-   // Enregistrement et rendu des fonctions de rappel ( callbacks) avec l'analyseur syntaxique
-   public static function onParserFirstCallInit( Parser $parser ) {
+	// Enregistrement et rendu des fonctions de rappel (callbacks) avec l'analyseur syntaxique
+	public static function onParserFirstCallInit( Parser $parser ) {
 
-      // Créer une fonction d'accroche en associant le  mot magique "subtitle" avec renderSubtitle()
-      $parser->setFunctionHook( 'subtitle', [ self::class, 'renderSubtitle' ] );
-   }
+		// Créer une fonction d'accroche en associant le mot magique "subtitle" avec renderSubtitle()
+		$parser->setFunctionHook( 'subtitle', [ self::class, 'renderSubtitle' ] );
+	}
 
-   // Rendu du résultat de {{#subtitle:}}.
-   public static function renderSubtitle( Parser $parser, $subtitleText ) {
-	   global $wgOut;
+	// Rendu du résultat de {{#subtitle:}}.
+	public static function renderSubtitle( Parser $parser, $subtitleText ) {
+		global $wgOut;
 
-      // Put the subtitle in the tagline
-	  $parser->disableCache();
-	  $wgOut->addSubtitle( $parser->recursiveTagParse( $subtitleText ) );
+		// Put the subtitle in the tagline
+		$parser->disableCache();
+		$wgOut->addSubtitle( $parser->recursiveTagParse( $subtitleText ) );
 
-	  // Replace this magic word by a blank in the resulting wikitext
-      return $parser->insertStripItem( "", $parser->mStripState );
-   }
+		// Replace this magic word by a blank in the resulting wikitext
+		return $parser->insertStripItem( "", $parser->mStripState );
+	 }
 }


### PR DESCRIPTION
It is needed one change for MediaWiki 1.35, and this is still compatible with old versions (MW 1.27 and probably before).

I also converted the spaces to tabs as stated in [MediaWiki conventions](https://www.mediawiki.org/wiki/Manual:Coding_conventions#Tab_size) -- I have a config of 8 spaces per tabs and it looks unaligned since it was assumed 4 spaces per tab.