### PR TITLE
Replace use of Parser::$mStripState, deprecated in 1.35

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -8,6 +8,9 @@
 	"descriptionmsg": "customSubtitle-desc",
 	"type": "parserhook",
 	"manifest_version": 1,
+	"requires": {
+		"MediaWiki": ">= 1.34.0"
+	},
 	"MessagesDirs": {
 		"CustomSubtitle": [ "i18n" ]
 	},

--- a/src/CustomSubtitleHooks.php
+++ b/src/CustomSubtitleHooks.php
@@ -16,6 +16,6 @@ class CustomSubtitleHooks {
 		$wgOut->addSubtitle( $parser->recursiveTagParse( $subtitleText ) );
 
 		// Replace this magic word by a blank in the resulting wikitext
-		return $parser->insertStripItem( "", $parser->mStripState );
+		return $parser->insertStripItem( "", $parser->getStripState() );
 	 }
 }


### PR DESCRIPTION
The replacement, Parser::getStripState(), was added to MediaWiki in
1.34.  Accordingly, the minimum required MediaWiki version for this
extension has been bumped to 1.34.

Bug: T275160